### PR TITLE
fix: Add single release notes section and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@ Sample repository for testing the release notes generator
 
 1. Non conventional commit
 2. Fix commit with a single release notes section
+3. Fix commit with a single release notes section and an image


### PR DESCRIPTION
Add single notes section and an image

// release-notes
This is a fix with a release notes section and an image
![IMG_5443_d416a103800e7f6ba85634c25dcaebf3_2000](https://user-images.githubusercontent.com/695993/230783628-63d45827-1577-4fc3-af9b-1d7ffab86c60.PNG)

// release-notes
